### PR TITLE
Add file link on prosthesis structure data

### DIFF
--- a/developer/manual/case/README.md
+++ b/developer/manual/case/README.md
@@ -1,14 +1,14 @@
 # Case Information
 
 ## Summary
-RAYTeams에서 관리하는 Case 정보에 대한 문서를 정리합니다.
-RAYTemas에서는 Prosthesis, Orthodontics Case 를 지원합니다.
-물론, 그외의 치료 타입에 대해서도 데이터 공유가 가능합니다.(Case 정보 공유만 불가)
+RAYTeams에서 관리하는 Case 정보에 대한 문서를 정리합니다.   
+RAYTemas에서는 Prosthesis, Orthodontics Case 를 지원합니다.   
+그외의 치료 타입에 대해서도 데이터 공유가 가능합니다.(Case 정보 공유만 불가)
 
 ## Basic Concept
 
-교정/보철에 대한 케이스 정보(의뢰서)는 동일한 구조로 관리됩니다.
-물론, 치료 타입마다 사용되는 DataSet과 특정 항목들이 추가될 수 있습니다.
+교정/보철에 대한 케이스 정보(의뢰서)는 동일한 구조로 관리됩니다.   
+치료 타입마다 사용되는 DataSet과 특정 항목들이 추가될 수 있습니다.   
 Case 정보는 파일로 저장되며 RAYTeams의 Case 공유 대상에 포함됩니다.
 
 ## Structure
@@ -26,6 +26,7 @@ RAYTeams에서 관리하는 Case 정보는 아래의 공통적인 사항이 적�
   "type": "prosthesis",
   "provider": "rayteams",
   "report": {
+    "toothNumberingSystem": "FDI",
     "data": [],
     "medicalReport" : {},
     "connects": {},
@@ -33,7 +34,8 @@ RAYTeams에서 관리하는 Case 정보는 아래의 공통적인 사항이 적�
   },
   "revision": 1,
   "report_revisions": [],
-  "photos": {}
+  "photos": {},
+  "created": 1682989474966
 }
 ```
 ## Descriptions
@@ -44,6 +46,7 @@ RAYTeams에서 관리하는 Case 정보는 아래의 공통적인 사항이 적�
 | type | String | O | "prosthesis" or "orthodontics" |   |
 | provider | String | O | 리포트가 작성된 프로그램 <br /> - RAYTeams: ***rayteams***<br> - D+Manager: ***dds_manager*** <br> - OrthoSimulator: ***ortho_simulator*** |   |
 | report | Object | O | 작성된 리포트에 대한 내용 <br /> type value에 따라 다른 data 구조가 존재함 |  |
+| report.toothNumberingSystem | String | O | 치아번호 표시 방법 RAYTeams에서는 FDI 기준으로 표시함 |
 | report.data | Array[Oject] | O | 치아와 관련된 정보 | [Prosthesis Case](./prosthesis/prosthesis-structure-data.md) <br /> [Orthodontics Case](./ortho/ortho-structure-data.md) |  
 | report.connects | Object | X | 치아 선택 관련하여 연결관련된 정보  | [Prosthesis connections](./prosthesis/prosthesis-structure-connect.md)|  
 | report.medicalReport | Object | X | Orthodontics 에서 기록되는 진료 내용 | [Orthodontics medical records](./ortho/ortho-structure-medicalreport.md) |  
@@ -51,6 +54,5 @@ RAYTeams에서 관리하는 Case 정보는 아래의 공통적인 사항이 적�
 | revision | Number | X | 만약 리포트의 내용이 변경되었다면 변경된 최종 버전 숫자 |  
 | report_revisions | Array[Object] | X | Object로는 기존 Revision의 모든 데이터가 저장 |  |
 | photos | Object | X | 별도로 표시할 사진, 동영상, 3D 모델등의 정보 | [Photos](./common/common-structure.md#photos) |
+| created | timestamp | O | report의 생성 timestamp (밀리 세컨트 까지) |
 
-## Notice
-* 치아의 표기법은 [FDI 표준](https://en.wikipedia.org/wiki/FDI_World_Dental_Federation_notation)을 따릅니다.

--- a/developer/manual/case/prosthesis/prosthesis-dataset.md
+++ b/developer/manual/case/prosthesis/prosthesis-dataset.md
@@ -1,4 +1,4 @@
-# Prosthesis DataSet
+# Prosthesis Data
 
 ## Summary
 

--- a/developer/manual/case/prosthesis/prosthesis-structure-connect.md
+++ b/developer/manual/case/prosthesis/prosthesis-structure-connect.md
@@ -36,8 +36,12 @@ Prosthesis Case에서 Connect 정보를 표현하는 방법에 대해서 설명�
 | Name | Type | Required | Description |
 | -- | -- | -- | -- |
 | {cKey} | String | O | 키값의 문자열, prefix로 ```c```를 가짐<br>```c + toothNumberA + toothNumberB``` 조합 형태로 구성 <br>**toothNumberA는 항상 toothNumberB보다 작은 값** |
-| {cKey}.code | String | O | 값은 {cKey} 와 같다. |
+| {cKey}.code | String | O | 값은 {cKey} 와 같음 |
 | {cKey}.keys | String | O | 구성된 치아 번호의 배열 (순서 무시, [FDI 표기법](https://en.wikipedia.org/wiki/FDI_World_Dental_Federation_notation)의 번호) |
 | {cKey}.state | String | O | 추후 활용을 위한 빈 값 |
 | {cKey}.visible | String | O | 연결 가능 상태를 보일지 여부<br>select가 true 경우 반드시 true이어야함 |
 | {cKey}.select | String | O | 연결된 여부 <br>false인 경우 visible이 true인 경우 연결되지 않은 상태로 보여짐 |
+
+
+## Sample
+[Prosthesis Sample](./prosthesis-sample.md)

--- a/developer/manual/case/prosthesis/prosthesis-structure-data.md
+++ b/developer/manual/case/prosthesis/prosthesis-structure-data.md
@@ -38,3 +38,9 @@ Prosthesis Case에서 Data 정보를 표현하는 방법에 대해서 설명합�
 | report.data[n].type | String | O |해당 치아의 진료 Type |
 | report.data[n].material | String | X | 해당 치아의 소재 |
 | report.data[n].shade | String | X | 해당 치아의 쉐이드 <br> ":"로 분리하여 앞에 문자는 Shade System의 값 뒤 문자는 실제 쉐이드 값 |
+
+## Dataset
+[Prosthesis Teeth Dataset](./prosthesis-dataset.md)
+
+## Sample
+[Prosthesis Sample](./prosthesis-sample.md)


### PR DESCRIPTION
변경 점
 - Case README.md 파일에 기본 props이 추가되었습니다.
 - 보철 예시에서 데이터 구조와 샘플을 볼 수 있는 링크가 추가되었습니다.
 - 보철 연결 예시에서 샘플을 볼 수 있는 링크가 추가되었습니다.