### PR TITLE
[RAYL-1847], 오기제된 medicalReport 키 수정

### DIFF
--- a/manual/case/ortho/README.md
+++ b/manual/case/ortho/README.md
@@ -12,3 +12,5 @@
 ## Change Histories
 - 23.10.26
   - Orthodontics case medical report에 값이 추가되었습니다. [확인](./ortho-structure-medicalreport.md)
+- 23.11.01
+  - Orthodontics case medical report에 잘못 표기된 값이 수정되었습니다. [확인](./ortho-structure-medicalreport.md)

--- a/manual/case/ortho/ortho-structure-medicalreport.md
+++ b/manual/case/ortho/ortho-structure-medicalreport.md
@@ -7,7 +7,10 @@
       추가된 선택지는 ```{ "value": "midline", "label": "Midline" }``` 입니다.
     - selectingTeethToMove 가 추가되었습니다.   
       3-3, 5-5, 7-7의 값을 가질 수 있습니다.
-
+- 2023.11.01
+    - medicalRecords로 잘못 기제된 prop 이름이 수정되었습니다.   
+      As-Is: medicalRecords   
+      To-Be: medicalReport
 
 ## Summary
 
@@ -20,7 +23,7 @@
 {
     "report": {
         ...
-        "medicalRecords": {
+        "medicalReport": {
             "conditions": [
                 "crowding",
                 "spacing",


### PR DESCRIPTION
샘플로 제공된 데이터 셋과 다른 키로 적용되어있던 가이드 문서를 수정했습니다.
As-Is: medicalRecords   
To-Be: medicalReport